### PR TITLE
feature: time specification nicknames support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file. This change
 
 Nothing here yet.
 
+### Added
+
+- Time specification "nicknames" support, e.g. `@yearly`, `@monthly`,
+  `@daily`, etc. ([32](https://github.com/pilosus/kairos/issues/32))
+
 ## [v0.2.45] - 2025-12-16
 
 ### Added

--- a/src/org/pilosus/kairos.clj
+++ b/src/org/pilosus/kairos.clj
@@ -63,6 +63,14 @@
    #"jan" "1" #"feb" "2" #"mar" "3" #"apr" "4" #"may" "5" #"jun" "6"
    #"jul" "7" #"aug" "8" #"sep" "9" #"oct" "10" #"nov" "11" #"dec" "12"})
 
+(def cron-nicknames
+  {"@yearly" "0 0 1 1 *"
+   "@annually" "0 0 1 1 *"
+   "@monthly" "0 0 1 * *"
+   "@weekly" "0 0 * * 0"  ;; on Sundays
+   "@daily" "0 0 * * *"
+   "@hourly" "0 * * * *"})
+
 ;; ISO-8601 day-of-week mapping
 (def day-number->name
   {1 "Monday"
@@ -224,7 +232,9 @@
 (defn- names->numbers
   "Replace month and day of week names with respective numeric values"
   [^String s]
-  (replace-names-with-numbers s (seq substitute-values)))
+  (if-let [expanded (cron-nicknames s)]
+    expanded
+    (replace-names-with-numbers s (seq substitute-values))))
 
 (defn- split-cron-string
   "Split cron string to [minute hour day-of-month month day-of-week]"

--- a/test/org/pilosus/kairos_test.clj
+++ b/test/org/pilosus/kairos_test.clj
@@ -298,7 +298,55 @@
      (kairos/get-dt 1970 1 1 0 3)
      (kairos/get-dt 1970 1 1 0 4)
      (kairos/get-dt 1970 1 1 0 5)]
-    "At every minute"]])
+    "At every minute"]
+   ["@yearly"
+    (kairos/get-dt 1970 1 1 0 0)
+    3
+    [(kairos/get-dt 1971 1 1 0 0)
+     (kairos/get-dt 1972 1 1 0 0)
+     (kairos/get-dt 1973 1 1 0 0)]
+    "Every year on January 1st at 00:00"]
+   ["@annually"
+    (kairos/get-dt 1970 1 1 0 0)
+    3
+    [(kairos/get-dt 1971 1 1 0 0)
+     (kairos/get-dt 1972 1 1 0 0)
+     (kairos/get-dt 1973 1 1 0 0)]
+    "Every year on January 1st at 00:00"]
+   ["@monthly"
+    (kairos/get-dt 1970 1 1 23 55)
+    3
+    [(kairos/get-dt 1970 2 1 0 0)
+     (kairos/get-dt 1970 3 1 0 0)
+     (kairos/get-dt 1970 4 1 0 0)]
+    "Every 1st day of the month at 00:00"]
+   ["@weekly"
+    (kairos/get-dt 1970 1 1 23 55)
+    5
+    [(kairos/get-dt 1970 1 4 0 0)
+     (kairos/get-dt 1970 1 11 0 0)
+     (kairos/get-dt 1970 1 18 0 0)
+     (kairos/get-dt 1970 1 25 0 0)
+     (kairos/get-dt 1970 2 1 0 0)]
+    "Every week on Sundays at 00:00"]
+   ["@daily"
+    (kairos/get-dt 1970 1 1 23 55)
+    5
+    [(kairos/get-dt 1970 1 2 0 0)
+     (kairos/get-dt 1970 1 3 0 0)
+     (kairos/get-dt 1970 1 4 0 0)
+     (kairos/get-dt 1970 1 5 0 0)
+     (kairos/get-dt 1970 1 6 0 0)]
+    "Every day at 00:00"]
+   ["@hourly"
+    (kairos/get-dt 1970 1 1 22 0)
+    5
+    [(kairos/get-dt 1970 1 1 23 0)
+     (kairos/get-dt 1970 1 2 0 0)
+     (kairos/get-dt 1970 1 2 1 0)
+     (kairos/get-dt 1970 1 2 2 0)
+     (kairos/get-dt 1970 1 2 3 0)]
+    "Every hour at 00:00"]])
 
 (deftest test-cron->dt
   (testing "Test generate a sequence of Date-Time objects:"


### PR DESCRIPTION
Crontab time specification aliases supported:
- `@yearly`
- `@annually`
- `@monthly`
- `@weekly`
- `@daily`
- `@hourly`

Another alias `@reboot` is skipped as non-actinable in terms of generating a sequence of DateTime objects.

Addresses:
https://github.com/pilosus/kairos/issues/32