### PR TITLE
tech: CI step and Makefile target to test GraalVM native-image compilation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,3 +49,39 @@ jobs:
         run: clojure -T:build ci :snapshot true :test-disable true
       - name: Check cljdoc
         run: curl -fsSL https://raw.githubusercontent.com/cljdoc/cljdoc/master/script/verify-cljdoc-edn | bash -s doc/cljdoc.edn
+
+  native-image:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '21'
+          distribution: 'graalce'
+      - name: Setup Clojure
+        uses: DeLaGuardo/setup-clojure@13.5
+        with:
+          cli: '1.12.4.1582'
+      - name: Cache Clojure Deps
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.clojure
+            ~/.cpcache
+            ~/.gitlibs
+            ~/.m2/repository
+          key: ${{ runner.os }}-graal-${{ hashFiles('**/deps.edn') }}
+      - name: Compile and build native image
+        run: |
+          mkdir -p classes
+          clojure -Sdeps '{:paths ["src" "test"]}' -M -e "(compile 'org.pilosus.kairos-graalvm-test)"
+          native-image \
+            --no-fallback \
+            -cp "$(clojure -Sdeps '{:paths ["src" "test"]}' -Spath):classes" \
+            --initialize-at-build-time \
+            -H:Class=org.pilosus.kairos_graalvm_test \
+            -o kairos-graalvm-test
+      - name: Smoke test native image
+        run: ./kairos-graalvm-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: '21'
-          distribution: 'graalce'
+          distribution: 'graalvm-community'
       - name: Setup Clojure
         uses: DeLaGuardo/setup-clojure@13.5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Nothing here yet.
 - Time specification "nicknames" support, e.g. `@yearly`, `@monthly`,
   `@daily`, etc. ([32](https://github.com/pilosus/kairos/issues/32))
 
+- Explicit testing for GraalVM native-image compilation
+  ([38](https://github.com/pilosus/kairos/issues/38))
+
 ## [v0.2.45] - 2025-12-16
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test cov ci check-build eastwood fmt outdated outdated-bump revcount
+.PHONY: test cov ci check-build eastwood fmt outdated outdated-bump revcount graalvm-test
 
 lint: fmt eastwood build-check
 all: lint ci
@@ -29,3 +29,24 @@ outdated-bump:
 
 revcount:
 	git rev-list HEAD --count
+
+# GraalVM native-image smoke test.
+# Verifies the library works when compiled to a native binary.
+# Requires GraalVM with native-image:
+#   brew install --cask graalvm-jdk          (macOS)
+#   sdk install java 21.0.7-graalce          (sdkman)
+#   https://www.graalvm.org/downloads/       (manual)
+GRAALVM_HOME ?= $(shell /usr/libexec/java_home -v "25" 2>/dev/null || /usr/libexec/java_home -v "21" 2>/dev/null || echo "")
+NATIVE_IMAGE := $(if $(wildcard $(GRAALVM_HOME)/bin/native-image),$(GRAALVM_HOME)/bin/native-image,$(shell command -v native-image 2>/dev/null))
+
+graalvm-test:
+	@test -n "$(NATIVE_IMAGE)" || { echo "native-image not found. Install GraalVM: https://www.graalvm.org/downloads/"; exit 1; }
+	mkdir -p classes
+	JAVA_HOME=$(GRAALVM_HOME) clojure -Sdeps '{:paths ["src" "test"]}' -M -e "(compile 'org.pilosus.kairos-graalvm-test)"
+	$(NATIVE_IMAGE) --no-fallback \
+		-cp "$$(JAVA_HOME=$(GRAALVM_HOME) clojure -Sdeps '{:paths ["src" "test"]}' -Spath):classes" \
+		--initialize-at-build-time \
+		-H:Class=org.pilosus.kairos_graalvm_test \
+		-o kairos-graalvm-test
+	./kairos-graalvm-test
+	rm -f kairos-graalvm-test

--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ Crontab parser for Clojure with plain-English cron explanations.
 ;; at minute 0, past hour 6, every 2nd hour from 10 through 18, hour 22, on every day of week from Monday through Friday, in every month
 ```
 
+## GraalVM Native Image
+
+The library is compatible with GraalVM native-image compilation. It
+has zero external dependencies and uses only `java.time` interop with
+no runtime reflection, so that it's safe for ahead-of-time
+compilation.
+
+```
+;; AOT-compile your namespace, then:
+;; native-image --no-fallback \
+;;   --initialize-at-build-time \
+;;   -cp "$(clojure -Spath):classes" \
+;;   -H:Class=your.main.ns \
+;;   -o your-app
+```
+
+
 ## License
 
 See [LICENSE](https://github.com/pilosus/kairos/tree/main/LICENSE).

--- a/test/org/pilosus/kairos_graalvm_test.clj
+++ b/test/org/pilosus/kairos_graalvm_test.clj
@@ -1,0 +1,18 @@
+(ns org.pilosus.kairos-graalvm-test
+  "Smoke test entry point for GraalVM native-image verification.
+   Not part of the library — only used by `make graalvm-test`."
+  (:require [org.pilosus.kairos :as k])
+  (:gen-class))
+
+(defn -main [& _]
+  (let [text (k/cron->text "*/5 * * * *")
+        validation (k/cron-validate "0 10 * * Mon-Fri")
+        dts (take 3 (k/cron->dt "@hourly" {:start (k/get-dt 2025 1 1 0 0)}))]
+    (println text)
+    (println validation)
+    (doseq [dt dts]
+      (println dt))
+    (when (and (string? text)
+               (:ok? validation)
+               (= 3 (count dts)))
+      (println "OK"))))


### PR DESCRIPTION
A CI step and a Makefile target have been added to run tests for GraalVM native-image compilation.

Closes:
https://github.com/pilosus/kairos/issues/38