### PR TITLE
feature: cron->text to support locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Nothing here yet.
   Monday through Friday, in every month`
   ([40](https://github.com/pilosus/kairos/issues/40))
 
+- Support locales for `cron->text`. Predefined locales: English
+  (default), German, Russian
+  ([42](https://github.com/pilosus/kairos/issues/42))
+
 ## [v0.2.45] - 2025-12-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![Clojars Project](https://img.shields.io/clojars/v/org.pilosus/kairos.svg)](https://clojars.org/org.pilosus/kairos)
 [![codecov](https://codecov.io/gh/pilosus/kairos/branch/main/graph/badge.svg?token=8OKTCKNq17)](https://codecov.io/gh/pilosus/kairos)
 
-Crontab parser for Clojure with plain-English cron explanations.
+Crontab parser for Clojure with plain-English cron explanations. Other languages supported via locales.
 
 - Supports [vixie-cron](https://man7.org/linux/man-pages/man5/crontab.5.html) syntax, inlcuding special aliases
 - Parses a `crontab` entry into a lazy sequence of `java.time.ZonedDateTime` objects in given timezone or `UTC` by default
-- Explains a `crontab` entry in plain English
+- Explains a `crontab` entry in plain English or any other language via locales
 - GraalVM-ready
 
 *Kairos* (καιρός) means the right, critical, or opportune moment.
@@ -19,7 +19,8 @@ Crontab parser for Clojure with plain-English cron explanations.
 ## Usage
 
 ```clojure
-(require '[org.pilosus.kairos :as k])
+(require '[org.pilosus.kairos :as k]
+         '[org.pilosus.kairos.locale :as locale])
 
 ;; 1. Generate a sequence of Date Time objects for a given crontab entry
 (k/cron->dt "0 10 3,7 Dec Mon")
@@ -49,6 +50,11 @@ Crontab parser for Clojure with plain-English cron explanations.
 (k/cron->text "0 6,10-18/2,22 * * Mon-Fri")
 
 ;; at minute 0, past hour 6, every 2nd hour from 10 through 18, hour 22, on every day of week from Monday through Friday, in every month
+
+;; 4. Use locales to translate a crontab entry into your language
+(k/cron->text "0 0 * * 1-5" {:locale locale/de})
+
+;; jeden Werktag um Mitternacht
 ```
 
 ## GraalVM Native Image

--- a/src/org/pilosus/kairos.clj
+++ b/src/org/pilosus/kairos.clj
@@ -258,25 +258,144 @@
       names->numbers
       (string/split #"\s+")))
 
+;; Locales
+
+(defn- ordinal-en
+  "English ordinal: 1 -> 1st, 2 -> 2nd, 3 -> 3rd, 11 -> 11th, etc."
+  [n]
+  (let [last-one (mod n 10)
+        last-two (mod n 100)
+        suffix (cond
+                 (contains? #{11 12 13} last-two) "th"
+                 (= last-one 1) "st"
+                 (= last-one 2) "nd"
+                 (= last-one 3) "rd"
+                 :else "th")]
+    (format "%s%s" n suffix)))
+
+(def locale-en
+  {:day-names          day-number->name
+   :month-names        month-number->name
+   :field-names        field->name
+   :nicknames          nickname->text
+   :ordinal-fn         ordinal-en
+   :time-fn            nil
+   :midnight           "midnight"
+   :every-day          "every day"
+   :every-minute       "every minute"
+   :weekday            "weekday"
+   :weekend            "weekend"
+   :fmt/verbose        "at %s, past %s, on %s, in %s"
+   :fmt/or             "%s or %s"
+   :fmt/every-unit     "every %s"
+   :fmt/every-nth      "every %s %s"
+   :fmt/unit-value     "%s %s"
+   :fmt/range          "every %s from %s through %s"
+   :fmt/range-step     "every %s %s from %s through %s"
+   :fmt/every-n-minutes    "every %s minutes"
+   :fmt/every-n-hours      "every %s hours"
+   :fmt/every-dow-at       "every %s at %s"
+   :fmt/every-dom-at       "every %s of the month at %s"
+   :fmt/every-month-dom-at "every %s %s at %s"
+   :fmt/every-day-at       "every day at %s"})
+
+(defn- resolve-locale [locale]
+  (merge locale-en (or locale {})))
+
 ;; Parsing cron into human-readable text
+
+(defn- value-fragment->text*
+  "Parse a fragment of the value into human-readable text using locale.
+   case-form can be :nominative (default) or :genitive for range start values."
+  ([s field locale] (value-fragment->text* s field locale :nominative))
+  ([s field locale case-form]
+   (case field
+     :month
+     (when-let [number (try (Integer/parseInt s) (catch Exception _ nil))]
+       (let [names (if (and (= case-form :genitive) (:month-names-genitive locale))
+                     (:month-names-genitive locale)
+                     (:month-names locale))]
+         (get names number)))
+     :day-of-week
+     (when-let [number (try (Integer/parseInt s) (catch Exception _ nil))]
+       (let [names (if (and (= case-form :genitive) (:day-names-genitive locale))
+                     (:day-names-genitive locale)
+                     (:day-names locale))]
+         (get names (zero->seven number))))
+     s)))
 
 (defmulti value-fragment->text
   "Parse a frament of the value into a human readable text"
   (fn [_ field] field))
 
 (defmethod value-fragment->text :month [s _]
-  (when-let [number (try (Integer/parseInt s) (catch Exception _ nil))]
-    (->> number
-         (get month-number->name))))
+  (value-fragment->text* s :month locale-en))
 
 (defmethod value-fragment->text :day-of-week [s _]
-  (when-let [number (try (Integer/parseInt s) (catch Exception _ nil))]
-    (->> number
-         zero->seven
-         (get day-number->name))))
+  (value-fragment->text* s :day-of-week locale-en))
 
 (defmethod value-fragment->text :default [s _]
-  s)
+  (value-fragment->text* s :default locale-en))
+
+(defn- value->text*
+  "Parse a string with the values into human-readable text using locale"
+  [s field locale]
+  (let [matcher (re-matcher value-regex s)]
+    (if (.matches matcher)
+      (let [field-fmts (get-in locale [:field-fmts field])
+            unit (get (:field-names locale) field)
+            article (get-in locale [:field-articles field])
+            qual-unit (if article (str article " " unit) unit)
+            start (.group matcher "start")
+            step (.group matcher "step")
+            end (.group matcher "end")
+            parsed-start (value-fragment->text* start field locale)
+            parsed-start-gen (value-fragment->text* start field locale :genitive)
+            ordinal-fn (or (get-in locale [:field-ordinals field])
+                           (:ordinal-fn locale))
+            parsed-step (when step (ordinal-fn (Integer/parseInt step)))
+            parsed-end (value-fragment->text* end field locale)]
+        (cond
+          (and
+           (= start "*")
+           (nil? step)) (if field-fmts
+                          (:fmt/every-unit field-fmts)
+                          (format (:fmt/every-unit locale) qual-unit))
+          (and
+           (= start "*")
+           (some? step)) (if field-fmts
+                           (format (:fmt/every-nth field-fmts) parsed-step)
+                           (if article
+                             (format (:fmt/every-nth locale)
+                                     (str article " " parsed-step " " unit))
+                             (format (:fmt/every-nth locale) parsed-step unit)))
+          (and
+           (some? start)
+           (nil? end)) (if field-fmts
+                         (format (:fmt/unit-value field-fmts) parsed-start)
+                         (format (:fmt/unit-value locale) unit parsed-start))
+          (and
+           (some? start)
+           (some? end)
+           (nil? step)) (if field-fmts
+                          (format (:fmt/range field-fmts)
+                                  parsed-start-gen parsed-end)
+                          (format (:fmt/range locale)
+                                  qual-unit parsed-start parsed-end))
+          (and
+           (some? start)
+           (some? end)
+           (some? step)) (if field-fmts
+                           (format (:fmt/range-step field-fmts)
+                                   parsed-step parsed-start-gen parsed-end)
+                           (if article
+                             (format (:fmt/range-step locale)
+                                     (str article " " parsed-step " " unit)
+                                     parsed-start parsed-end)
+                             (format (:fmt/range-step locale)
+                                     parsed-step unit parsed-start parsed-end)))
+          :else nil))
+      nil)))
 
 (defmulti value->text
   "Parse a string with the values into a human-readable text"
@@ -284,47 +403,19 @@
 
 (defmethod value->text :default
   [s field]
-  (let [matcher (re-matcher value-regex s)]
-    (if (.matches matcher)
-      (let [unit (get field->name field)
-            start (.group matcher "start")
-            step (.group matcher "step")
-            end (.group matcher "end")
-            parsed-start (value-fragment->text start field)
-            parsed-step (value->ordinal step)
-            parsed-end (value-fragment->text end field)]
-        ;; start is guaranteed to be non-empty by the regex,
-        ;; yet we keep it in the cond for readability
-        (cond
-          (and
-           (= start "*")
-           (nil? step)) (format "every %s" unit)
-          (and
-           (= start "*")
-           (some? step)) (format "every %s %s" parsed-step unit)
-          (and
-           (some? start)
-           (nil? end)) (format "%s %s" unit parsed-start)
-          (and
-           (some? start)
-           (some? end)
-           (nil? step)) (format "every %s from %s through %s"
-                                unit parsed-start parsed-end)
-          (and
-           (some? start)
-           (some? end)
-           (some? step)) (format "every %s %s from %s through %s"
-                                 parsed-step unit parsed-start parsed-end)
-          :else nil))
-      nil)))
+  (value->text* s field locale-en))
+
+(defn- field->text*
+  "Parse field values into human-readable text using locale"
+  [s field locale]
+  (let [lists (string/split s list-regex)
+        parsed-values (map #(value->text* % field locale) lists)]
+    (string/join ", " parsed-values)))
 
 (defn field->text
   "Parse field values into a human readable text"
   [s field]
-  (let [lists (string/split s list-regex)
-        parsed-values (map #(value->text % field) lists)
-        result (string/join ", " parsed-values)]
-    result))
+  (field->text* s field locale-en))
 
 ;; Date-Time sequence generation
 
@@ -391,44 +482,47 @@
 ;; Simplified text
 
 (defn- simple-time->text
-  [minute hour]
-  (cond
-    (and (= minute "0") (= hour "0")) "midnight"
-    (and (= minute "0") (not= hour "0")) (format "%s:00" hour)
-    (and (re-matches #"\d+" minute) (re-matches #"\d+" hour))
-    (format "%s:%02d" hour (Integer/parseInt minute))
-    :else nil))
+  [minute hour locale]
+  (if-let [time-fn (:time-fn locale)]
+    (time-fn hour minute)
+    (cond
+      (and (= minute "0") (= hour "0")) (:midnight locale)
+      (and (= minute "0") (not= hour "0")) (format "%s:00" hour)
+      (and (re-matches #"\d+" minute) (re-matches #"\d+" hour))
+      (format "%s:%02d" hour (Integer/parseInt minute))
+      :else nil)))
 
 (defn- simple-day-of-month->text
-  [day-of-month]
-  (value->ordinal day-of-month))
+  [day-of-month locale]
+  (when-let [number (try (Integer/parseInt day-of-month) (catch Exception _ nil))]
+    ((:ordinal-fn locale) number)))
 
 (defn- simple-month->text
-  [month]
-  (value-fragment->text month :month))
+  [month locale]
+  (value-fragment->text* month :month locale))
 
 (defn- simple-day-of-week->text
-  [day-of-week]
+  [day-of-week locale]
   (cond
     (or (= day-of-week "1-5")
-        (= day-of-week "1,2,3,4,5")) "weekday"
+        (= day-of-week "1,2,3,4,5")) (:weekday locale)
     (or (= day-of-week "6,0")
         (= day-of-week "6,7")
-        (= day-of-week "6-7")) "weekend"
+        (= day-of-week "6-7")) (:weekend locale)
     :else nil))
 
 (defn- cron->simple-text
-  [s]
-  (let [nicknamed (nickname->text s)]
+  [s locale]
+  (let [nicknamed (get (:nicknames locale) (-> s string/trim string/lower-case))]
     (if nicknamed
       nicknamed
       (try
         (cron->map-unsafe s)
         (let [[minute hour day-of-month month day-of-week] (split-cron-string s)
-              time (simple-time->text minute hour)
-              dow (simple-day-of-week->text day-of-week)
-              dom (simple-day-of-month->text day-of-month)
-              mon (simple-month->text month)]
+              time (simple-time->text minute hour locale)
+              dow (simple-day-of-week->text day-of-week locale)
+              dom (simple-day-of-month->text day-of-month locale)
+              mon (simple-month->text month locale)]
           (cond
             ;; */5 * * * *  ->  "every 5 minutes"
             (and (= hour "*")
@@ -436,8 +530,9 @@
                  (= month "*")
                  (= day-of-week "*")
                  (re-matches number-with-step-regex minute))
-            (format "every %s minutes"
-                    (second (re-matches number-with-step-regex minute)))
+            (let [v (second (re-matches number-with-step-regex minute))
+                  fmt (:fmt/every-n-minutes locale)]
+              (if (fn? fmt) (fmt v) (format fmt v)))
 
              ;; * * * * *  ->  "every minute"
             (and (= minute "*")
@@ -445,7 +540,7 @@
                  (= day-of-month "*")
                  (= month "*")
                  (= day-of-week "*"))
-            "every minute"
+            (:every-minute locale)
 
             ;; 0 */2 * * *  ->  "every 2 hours"
             (and (= minute "0")
@@ -453,8 +548,9 @@
                  (= month "*")
                  (= day-of-week "*")
                  (re-matches number-with-step-regex hour))
-            (format "every %s hours"
-                    (second (re-matches number-with-step-regex hour)))
+            (let [v (second (re-matches number-with-step-regex hour))
+                  fmt (:fmt/every-n-hours locale)]
+              (if (fn? fmt) (fmt v) (format fmt v)))
 
             ;; fixed time + all days + all months + specific dow
             ;; 0 9 * * 1-5 -> "every weekday at 9:00"
@@ -462,7 +558,7 @@
                  (= day-of-month "*")
                  (= month "*")
                  dow)
-            (format "every %s at %s" dow time)
+            (format (:fmt/every-dow-at locale) dow time)
 
             ;; fixed time + specific dom + all months + all dow
             ;; 30 8 15 * *  ->  "every 15th of the month at 8:30"
@@ -470,7 +566,7 @@
                  dom
                  (= month "*")
                  (= day-of-week "*"))
-            (format "every %s of the month at %s" dom time)
+            (format (:fmt/every-dom-at locale) dom time)
 
             ;; fixed time + specific dom + specific month + all dow
             ;; 0 0 25 12 *  ->  "every December 25th at midnight"
@@ -478,7 +574,10 @@
                  dom
                  mon
                  (= day-of-week "*"))
-            (format "every %s %s at %s" mon dom time)
+            (let [fmt (:fmt/every-month-dom-at locale)]
+              (if (fn? fmt)
+                (fmt {:day-of-month day-of-month :month month :time time :locale locale})
+                (format fmt mon dom time)))
 
             ;; fixed time + all days + all months + all dow
             ;; 30 8 * * *  ->  "every day at 8:30"
@@ -486,7 +585,7 @@
                  (= day-of-month "*")
                  (= month "*")
                  (= day-of-week "*"))
-            (format "every day at %s" time)
+            (format (:fmt/every-day-at locale) time)
 
             ;; nothing matched -> nil, fall through to verbose
             :else nil))
@@ -554,25 +653,35 @@
      results)))
 
 (defn cron->text
-  "Parse crontab string into a human-readable text"
-  [s]
-  (or (cron->simple-text s)
-      (try
-        (cron->map-unsafe s)
-        (let [[minute hour day-of-month month day-of-week] (split-cron-string s)
-              day-of-month' (field->text day-of-month :day-of-month)
-              day-of-week' (field->text day-of-week :day-of-week)
-              minute' (field->text minute :minute)
-              hour' (field->text hour :hour)
-              day' (cond
-                     (and (= day-of-month "*")
-                          (not (= day-of-week "*"))) (field->text day-of-week :day-of-week)
-                     (and (not (= day-of-month "*"))
-                          (= day-of-week "*")) (field->text day-of-month :day-of-month)
-                     (and (not (= day-of-month "*"))
-                          (not (= day-of-week "*"))) (format "%s or %s" day-of-month' day-of-week')
-                     :else "every day")
-              month' (field->text month :month)
-              text (format "at %s, past %s, on %s, in %s" minute' hour' day' month')]
-          text)
-        (catch Exception _ nil))))
+  "Parse crontab string into a human-readable text.
+   opts:
+     :locale - a locale map for translations (default: English).
+               Partial maps are merged with the English defaults.
+               See locale-en for the full schema."
+  ([s] (cron->text s {}))
+  ([s {:keys [locale]}]
+   (let [resolved (resolve-locale locale)]
+     (or (cron->simple-text s resolved)
+         (try
+           (cron->map-unsafe s)
+           (let [[minute hour day-of-month month day-of-week] (split-cron-string s)
+                 day-of-month' (field->text* day-of-month :day-of-month resolved)
+                 day-of-week' (field->text* day-of-week :day-of-week resolved)
+                 minute' (field->text* minute :minute resolved)
+                 hour' (field->text* hour :hour resolved)
+                 day' (cond
+                        (and (= day-of-month "*")
+                             (not (= day-of-week "*"))) (field->text* day-of-week :day-of-week resolved)
+                        (and (not (= day-of-month "*"))
+                             (= day-of-week "*")) (field->text* day-of-month :day-of-month resolved)
+                        (and (not (= day-of-month "*"))
+                             (not (= day-of-week "*"))) (format (:fmt/or resolved) day-of-month' day-of-week')
+                        :else (:every-day resolved))
+                 month' (field->text* month :month resolved)
+                 text (if-let [verbose-fn (:fmt/verbose-fn resolved)]
+                        (verbose-fn {:minute minute' :hour hour'
+                                     :day day' :month month'
+                                     :minute-raw minute})
+                        (format (:fmt/verbose resolved) minute' hour' day' month'))]
+             text)
+           (catch Exception _ nil))))))

--- a/src/org/pilosus/kairos/locale.clj
+++ b/src/org/pilosus/kairos/locale.clj
@@ -1,0 +1,155 @@
+;; Copyright (c) Vitaly Samigullin and contributors. All rights reserved.
+;;
+;; This program and the accompanying materials are made available under the
+;; terms of the Eclipse Public License 2.0 which is available at
+;; http://www.eclipse.org/legal/epl-2.0.
+;;
+;; This Source Code may also be made available under the following Secondary
+;; Licenses when the conditions for such availability set forth in the Eclipse
+;; Public License, v. 2.0 are satisfied: GNU General Public License as published by
+;; the Free Software Foundation, either version 2 of the License, or (at your
+;; option) any later version, with the GNU Classpath Exception which is available
+;; at https://www.gnu.org/software/classpath/license.html.
+;;
+;; SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+(ns org.pilosus.kairos.locale
+  "Predefined locale maps for cron->text localization.
+   See org.pilosus.kairos/locale-en for the full schema.")
+
+(def de
+  {:day-names          {1 "Montag" 2 "Dienstag" 3 "Mittwoch" 4 "Donnerstag"
+                        5 "Freitag" 6 "Samstag" 7 "Sonntag"}
+   :month-names        {1 "Januar" 2 "Februar" 3 "März" 4 "April"
+                        5 "Mai" 6 "Juni" 7 "Juli" 8 "August"
+                        9 "September" 10 "Oktober" 11 "November" 12 "Dezember"}
+   :field-names        {:minute "Minute" :hour "Stunde"
+                        :day-of-month "Tag des Monats" :month "Monat"
+                        :day-of-week "Wochentag"}
+   :field-articles     {:minute "jeder" :hour "jeder"
+                        :day-of-month "jedem" :month "jedem"
+                        :day-of-week "jedem"}
+   :nicknames          {"@yearly"   "jeden 1. Januar um Mitternacht"
+                        "@annually" "jeden 1. Januar um Mitternacht"
+                        "@monthly"  "jeden 1. des Monats um Mitternacht"
+                        "@weekly"   "jeden Sonntag um Mitternacht"
+                        "@daily"    "jeden Tag um Mitternacht"
+                        "@hourly"   "jede Stunde"}
+   :ordinal-fn         (fn [n] (str n "."))
+   :time-fn            nil
+   :midnight           "Mitternacht"
+   :every-day          "jedem Tag"
+   :every-minute       "jede Minute"
+   :weekday            "jeden Werktag"
+   :weekend            "jedes Wochenende"
+   :fmt/verbose        "in %s, in %s, an %s, in %s"
+   :fmt/or             "%s oder an %s"
+   :fmt/every-unit     "%s"
+   :fmt/every-nth      "%s"
+   :fmt/unit-value     "%s %s"
+   :fmt/range          "%s von %s bis %s"
+   :fmt/range-step     "%s von %s bis %s"
+   :fmt/every-n-minutes    "alle %s Minuten"
+   :fmt/every-n-hours      "alle %s Stunden"
+   :fmt/every-dow-at       "%s um %s"
+   :fmt/every-dom-at       "jeden %s des Monats um %s"
+   :fmt/every-month-dom-at "jeden %2$s %1$s um %3$s"
+   :fmt/every-day-at       "jeden Tag um %s"})
+
+(defn- ru-plural
+  "Russian plural form for a numeric string.
+   Returns one of three forms based on standard Russian grammar rules:
+     form1 - for 1, 21, 31, ... (but not 11)
+     form2 - for 2-4, 22-24, 32-34, ... (but not 12-14)
+     form5 - for 0, 5-20, 25-30, ...
+   Example: (ru-plural \"2\" \"минуту\" \"минуты\" \"минут\") => \"минуты\""
+  [s form1 form2 form5]
+  (let [n (Integer/parseInt s)
+        last-two (mod n 100)
+        last-one (mod n 10)]
+    (cond
+      (<= 11 last-two 19) form5
+      (= last-one 1) form1
+      (<= 2 last-one 4) form2
+      :else form5)))
+
+(def ^:private ru-month-names-genitive
+  {1 "января" 2 "февраля" 3 "марта" 4 "апреля"
+   5 "мая" 6 "июня" 7 "июля" 8 "августа"
+   9 "сентября" 10 "октября" 11 "ноября" 12 "декабря"})
+
+(def ru
+  {:day-names          {1 "понедельник" 2 "вторник" 3 "среда" 4 "четверг"
+                        5 "пятница" 6 "суббота" 7 "воскресенье"}
+   :day-names-genitive {1 "понедельника" 2 "вторника" 3 "среды" 4 "четверга"
+                        5 "пятницы" 6 "субботы" 7 "воскресенья"}
+   :month-names        {1 "январь" 2 "февраль" 3 "март" 4 "апрель"
+                        5 "май" 6 "июнь" 7 "июль" 8 "август"
+                        9 "сентябрь" 10 "октябрь" 11 "ноябрь" 12 "декабрь"}
+   :month-names-genitive ru-month-names-genitive
+   :field-names        {:minute "минута" :hour "час"
+                        :day-of-month "день месяца" :month "месяц"
+                        :day-of-week "день недели"}
+   :field-fmts
+   {:minute       {:fmt/every-unit  "каждую минуту"
+                   :fmt/every-nth   "каждую %s минуту"
+                   :fmt/unit-value  "минуту %s"
+                   :fmt/range       "каждую минуту с %s по %s"
+                   :fmt/range-step  "каждую %s минуту с %s по %s"}
+    :hour         {:fmt/every-unit  "каждый час"
+                   :fmt/every-nth   "каждый %s час"
+                   :fmt/unit-value  "час %s"
+                   :fmt/range       "каждый час с %s по %s"
+                   :fmt/range-step  "каждый %s час с %s по %s"}
+    :day-of-month {:fmt/every-unit  "каждый день месяца"
+                   :fmt/every-nth   "каждый %s день месяца"
+                   :fmt/unit-value  "день месяца %s"
+                   :fmt/range       "каждый день месяца с %s по %s"
+                   :fmt/range-step  "каждый %s день месяца с %s по %s"}
+    :month        {:fmt/every-unit  "каждый месяц"
+                   :fmt/every-nth   "каждый %s месяц"
+                   :fmt/unit-value  "месяц %s"
+                   :fmt/range       "каждый месяц с %s по %s"
+                   :fmt/range-step  "каждый %s месяц с %s по %s"}
+    :day-of-week  {:fmt/every-unit  "каждый день недели"
+                   :fmt/every-nth   "каждый %s день недели"
+                   :fmt/unit-value  "день недели %s"
+                   :fmt/range       "каждый день недели с %s по %s"
+                   :fmt/range-step  "каждый %s день недели с %s по %s"}}
+   :field-ordinals {:minute       (fn [n] (str n "-ю"))
+                    :hour         (fn [n] (str n "-й"))
+                    :day-of-month (fn [n] (str n "-й"))
+                    :month        (fn [n] (str n "-й"))
+                    :day-of-week  (fn [n] (str n "-й"))}
+   :nicknames          {"@yearly"   "каждое 1 января в полночь"
+                        "@annually" "каждое 1 января в полночь"
+                        "@monthly"  "1-го числа каждого месяца в полночь"
+                        "@weekly"   "каждое воскресенье в полночь"
+                        "@daily"    "каждый день в полночь"
+                        "@hourly"   "каждый час"}
+   :ordinal-fn         (fn [n] (str n "-е"))
+   :time-fn            nil
+   :midnight           "полночь"
+   :every-day          "каждый день"
+   :every-minute       "каждую минуту"
+   :weekday            "будний день"
+   :weekend            "выходной"
+   :fmt/verbose        "%s, %s, %s, %s"
+   :fmt/verbose-fn     (fn [{:keys [minute hour day month minute-raw]}]
+                         (let [prefix (if (= minute-raw "*") "" "в ")]
+                           (str prefix minute ", " hour ", " day ", " month)))
+   :fmt/or             "%s или %s"
+   :fmt/every-unit     "каждый %s"
+   :fmt/every-nth      "каждый %s %s"
+   :fmt/unit-value     "%s %s"
+   :fmt/range          "каждый %s с %s по %s"
+   :fmt/range-step     "каждый %s %s с %s по %s"
+   :fmt/every-n-minutes    (fn [n] (format "каждые %s %s" n (ru-plural n "минуту" "минуты" "минут")))
+   :fmt/every-n-hours      (fn [n] (format "каждые %s %s" n (ru-plural n "час" "часа" "часов")))
+   :fmt/every-dow-at       "каждый %s в %s"
+   :fmt/every-dom-at       "каждое %s число месяца в %s"
+   :fmt/every-month-dom-at (fn [{:keys [day-of-month month time]}]
+                             (let [month-gen (get ru-month-names-genitive
+                                                  (Integer/parseInt month))]
+                               (format "каждое %s %s в %s" day-of-month month-gen time)))
+   :fmt/every-day-at       "каждый день в %s"})

--- a/test/org/pilosus/kairos_cron_to_text_test.clj
+++ b/test/org/pilosus/kairos_cron_to_text_test.clj
@@ -15,7 +15,8 @@
 
 (ns org.pilosus.kairos-cron-to-text-test
   (:require [clojure.test :refer [deftest is testing]]
-            [org.pilosus.kairos :as kairos])
+            [org.pilosus.kairos :as kairos]
+            [org.pilosus.kairos.locale :as locale])
   (:import (java.time ZonedDateTime ZoneId)))
 
 ;; Parsing cront into a human-readable text
@@ -95,7 +96,10 @@
     "Fixed time, specific day of month, specific month, all days of week"]
    ["30 8 * * *"
     "every day at 8:30"
-    "Fixed time, all days, all months, all days of week"]])
+    "Fixed time, all days, all months, all days of week"]
+   ["@weekly"
+    "every Sunday at midnight"
+    "Nickname @weekly"]])
 
 (deftest test-cron->text-simple-ok
   (testing "Test parsing crontab entry into a human-readable text"
@@ -140,3 +144,261 @@
     (doseq [[cron expected description] params-cron->text-complex-ok]
       (testing cron
         (is (= expected (kairos/cron->text cron)) description)))))
+
+;; Locale tests
+
+(def params-cron->text-de-simple
+  [["@yearly"
+    "jeden 1. Januar um Mitternacht"
+    "Nickname @yearly"]
+   ["@annually"
+    "jeden 1. Januar um Mitternacht"
+    "Nickname @annually"]
+   ["@monthly"
+    "jeden 1. des Monats um Mitternacht"
+    "Nickname @monthly"]
+   ["@weekly"
+    "jeden Sonntag um Mitternacht"
+    "Nickname @weekly"]
+   ["@daily"
+    "jeden Tag um Mitternacht"
+    "Nickname @daily"]
+   ["@hourly"
+    "jede Stunde"
+    "Nickname @hourly"]
+   ["* * * * *"
+    "jede Minute"
+    "Every minute"]
+   ["*/5 * * * *"
+    "alle 5 Minuten"
+    "Every 5 minutes"]
+   ["*/25 * * * *"
+    "alle 25 Minuten"
+    "Double-digit minutes with step"]
+   ["0 */2 * * *"
+    "alle 2 Stunden"
+    "Every 2 hours"]
+   ["0 */12 * * *"
+    "alle 12 Stunden"
+    "Double-digit hours with step"]
+   ["0 9 * * *"
+    "jeden Tag um 9:00"
+    "Every day at 9:00"]
+   ["30 8 * * *"
+    "jeden Tag um 8:30"
+    "Every day at 8:30"]
+   ["0 0 * * *"
+    "jeden Tag um Mitternacht"
+    "Every day at midnight"]
+   ["0 9 * * 1-5"
+    "jeden Werktag um 9:00"
+    "Every weekday at 9:00"]
+   ["0 9 * * 6,7"
+    "jedes Wochenende um 9:00"
+    "Every weekend at 9:00"]
+   ["0 9 * * 6,0"
+    "jedes Wochenende um 9:00"
+    "Every weekend at 9:00 (sun=0)"]
+   ["30 8 15 * *"
+    "jeden 15. des Monats um 8:30"
+    "Every 15th of month at 8:30"]
+   ["0 0 1 * *"
+    "jeden 1. des Monats um Mitternacht"
+    "Every 1st of the month at midnight"]
+   ["0 0 25 12 *"
+    "jeden 25. Dezember um Mitternacht"
+    "Every December 25th at midnight"]
+   ["0 0 1 1 *"
+    "jeden 1. Januar um Mitternacht"
+    "Every January 1st at midnight"]
+   ["0 0 14 2 *"
+    "jeden 14. Februar um Mitternacht"
+    "Every February 14th at midnight"]
+   ["0 12 3 10 *"
+    "jeden 3. Oktober um 12:00"
+    "Every October 3rd at noon"]])
+
+(deftest test-cron->text-de-simple
+  (testing "Test German locale simple patterns"
+    (doseq [[cron expected description] params-cron->text-de-simple]
+      (testing cron
+        (is (= expected (kairos/cron->text cron {:locale locale/de}))
+            description)))))
+
+(def params-cron->text-de-complex
+  [["3-17 * * * *"
+    "in jeder Minute von 3 bis 17, in jeder Stunde, an jedem Tag, in jedem Monat"
+    "Simple range value"]
+   ["10-20/2 * * * *"
+    "in jeder 2. Minute von 10 bis 20, in jeder Stunde, an jedem Tag, in jedem Monat"
+    "Explicit range with step"]
+   ["1,2,17 * * * *"
+    "in Minute 1, Minute 2, Minute 17, in jeder Stunde, an jedem Tag, in jedem Monat"
+    "Simple list of values"]
+   ["* * 1-15 * *"
+    "in jeder Minute, in jeder Stunde, an jedem Tag des Monats von 1 bis 15, in jedem Monat"
+    "Day of month only"]
+   ["* * * * 1-4"
+    "in jeder Minute, in jeder Stunde, an jedem Wochentag von Montag bis Donnerstag, in jedem Monat"
+    "Day of week only"]
+   ["* * 1-15 * 1-4"
+    "in jeder Minute, in jeder Stunde, an jedem Tag des Monats von 1 bis 15 oder an jedem Wochentag von Montag bis Donnerstag, in jedem Monat"
+    "Day of month OR day of week"]
+   ["* * * Jan-May *"
+    "in jeder Minute, in jeder Stunde, an jedem Tag, in jedem Monat von Januar bis Mai"
+    "Month range"]
+   ["cannot be parsed"
+    nil
+    "Wrong value"]])
+
+(deftest test-cron->text-de-complex
+  (testing "Test German locale verbose patterns"
+    (doseq [[cron expected description] params-cron->text-de-complex]
+      (testing cron
+        (is (= expected (kairos/cron->text cron {:locale locale/de}))
+            description)))))
+
+(def params-cron->text-ru-simple
+  [["@yearly"
+    "каждое 1 января в полночь"
+    "Nickname @yearly"]
+   ["@annually"
+    "каждое 1 января в полночь"
+    "Nickname @annually"]
+   ["@monthly"
+    "1-го числа каждого месяца в полночь"
+    "Nickname @monthly"]
+   ["@weekly"
+    "каждое воскресенье в полночь"
+    "Nickname @weekly"]
+   ["@daily"
+    "каждый день в полночь"
+    "Nickname @daily"]
+   ["@hourly"
+    "каждый час"
+    "Nickname @hourly"]
+   ["* * * * *"
+    "каждую минуту"
+    "Every minute"]
+   ["*/2 * * * *"
+    "каждые 2 минуты"
+    "Every 2 minutes"]
+   ["*/5 * * * *"
+    "каждые 5 минут"
+    "Every 5 minutes"]
+   ["*/3 * * * *"
+    "каждые 3 минуты"
+    "Every 3 minutes (form2 plural)"]
+   ["*/21 * * * *"
+    "каждые 21 минуту"
+    "Every 21 minutes (form1 plural)"]
+   ["*/25 * * * *"
+    "каждые 25 минут"
+    "Double-digit minutes with step"]
+   ["0 */2 * * *"
+    "каждые 2 часа"
+    "Every 2 hours"]
+   ["0 */5 * * *"
+    "каждые 5 часов"
+    "Every 5 hours"]
+   ["0 */12 * * *"
+    "каждые 12 часов"
+    "Double-digit hours with step"]
+   ["0 9 * * *"
+    "каждый день в 9:00"
+    "Every day at 9:00"]
+   ["30 8 * * *"
+    "каждый день в 8:30"
+    "Every day at 8:30"]
+   ["0 0 * * *"
+    "каждый день в полночь"
+    "Every day at midnight"]
+   ["0 9 * * 1-5"
+    "каждый будний день в 9:00"
+    "Every weekday at 9:00"]
+   ["0 9 * * 6,7"
+    "каждый выходной в 9:00"
+    "Every weekend at 9:00"]
+   ["0 9 * * 6,0"
+    "каждый выходной в 9:00"
+    "Every weekend at 9:00 (sun=0)"]
+   ["30 8 15 * *"
+    "каждое 15-е число месяца в 8:30"
+    "Every 15th of month at 8:30"]
+   ["0 0 1 * *"
+    "каждое 1-е число месяца в полночь"
+    "Every 1st of the month at midnight"]
+   ["0 0 25 12 *"
+    "каждое 25 декабря в полночь"
+    "Every December 25th at midnight"]
+   ["0 0 1 1 *"
+    "каждое 1 января в полночь"
+    "Every January 1st at midnight"]
+   ["0 0 14 2 *"
+    "каждое 14 февраля в полночь"
+    "Every February 14th at midnight"]
+   ["0 12 3 10 *"
+    "каждое 3 октября в 12:00"
+    "Every October 3rd at noon"]])
+
+(deftest test-cron->text-ru-simple
+  (testing "Test Russian locale simple patterns"
+    (doseq [[cron expected description] params-cron->text-ru-simple]
+      (testing cron
+        (is (= expected (kairos/cron->text cron {:locale locale/ru}))
+            description)))))
+
+(def params-cron->text-ru-complex
+  [["3-17 * * * *"
+    "в каждую минуту с 3 по 17, каждый час, каждый день, каждый месяц"
+    "Simple range value"]
+   ["10-20/2 * * * *"
+    "в каждую 2-ю минуту с 10 по 20, каждый час, каждый день, каждый месяц"
+    "Explicit range with step"]
+   ["1,2,17 * * * *"
+    "в минуту 1, минуту 2, минуту 17, каждый час, каждый день, каждый месяц"
+    "Simple list of values"]
+   ["* * 1-15 * *"
+    "каждую минуту, каждый час, каждый день месяца с 1 по 15, каждый месяц"
+    "Day of month only"]
+   ["* * * * 1-4"
+    "каждую минуту, каждый час, каждый день недели с понедельника по четверг, каждый месяц"
+    "Day of week only"]
+   ["* * 1-15 * 1-4"
+    "каждую минуту, каждый час, каждый день месяца с 1 по 15 или каждый день недели с понедельника по четверг, каждый месяц"
+    "Day of month OR day of week"]
+   ["* * * Jan-May *"
+    "каждую минуту, каждый час, каждый день, каждый месяц с января по май"
+    "Month range"]
+   ["cannot be parsed"
+    nil
+    "Wrong value"]])
+
+(deftest test-cron->text-ru-complex
+  (testing "Test Russian locale verbose patterns"
+    (doseq [[cron expected description] params-cron->text-ru-complex]
+      (testing cron
+        (is (= expected (kairos/cron->text cron {:locale locale/ru}))
+            description)))))
+
+(deftest test-cron->text-partial-locale
+  (testing "Partial locale overrides merge with English defaults"
+    (is (= "every day at minuit"
+           (kairos/cron->text "0 0 * * *" {:locale {:midnight "minuit"}})))
+    (is (= "every day at midnight"
+           (kairos/cron->text "0 0 * * *"))
+        "Default English unchanged"))
+  (testing "Custom time-fn"
+    (is (= "every day at 09h00"
+           (kairos/cron->text "0 9 * * *"
+                              {:locale {:time-fn (fn [h m] (format "%02dh%02d"
+                                                                   (Integer/parseInt h)
+                                                                   (Integer/parseInt m)))}})))))
+
+(deftest test-public-wrappers
+  (testing "Public multimethod wrappers still work"
+    (is (= "January" (kairos/value-fragment->text "1" :month)))
+    (is (= "Monday" (kairos/value-fragment->text "1" :day-of-week)))
+    (is (= "5" (kairos/value-fragment->text "5" :minute)))
+    (is (= "every minute" (kairos/value->text "*" :minute)))
+    (is (= "every minute, minute 5" (kairos/field->text "*,5" :minute)))))


### PR DESCRIPTION
`cron->text` now supports user-defined locales to translate cron text representation into their target language. Default locale is English.

Closed:
https://github.com/pilosus/kairos/issues/42