### PR TITLE
feature: Spanish locale for cron->text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Nothing here yet.
   ([40](https://github.com/pilosus/kairos/issues/40))
 
 - Support locales for `cron->text`. Predefined locales: English
-  (default), German, Russian
+  (default), German, Russian, Spanish
   ([42](https://github.com/pilosus/kairos/issues/42))
 
 ## [v0.2.45] - 2025-12-16

--- a/src/org/pilosus/kairos/locale.clj
+++ b/src/org/pilosus/kairos/locale.clj
@@ -56,6 +56,85 @@
    :fmt/every-month-dom-at "jeden %2$s %1$s um %3$s"
    :fmt/every-day-at       "jeden Tag um %s"})
 
+(def ^:private es-month-names-genitive
+  {1 "enero" 2 "febrero" 3 "marzo" 4 "abril"
+   5 "mayo" 6 "junio" 7 "julio" 8 "agosto"
+   9 "septiembre" 10 "octubre" 11 "noviembre" 12 "diciembre"})
+
+(def es
+  {:day-names          {1 "lunes" 2 "martes" 3 "miércoles" 4 "jueves"
+                        5 "viernes" 6 "sábado" 7 "domingo"}
+   :month-names        {1 "enero" 2 "febrero" 3 "marzo" 4 "abril"
+                        5 "mayo" 6 "junio" 7 "julio" 8 "agosto"
+                        9 "septiembre" 10 "octubre" 11 "noviembre" 12 "diciembre"}
+   :field-names        {:minute "minuto" :hour "hora"
+                        :day-of-month "día del mes" :month "mes"
+                        :day-of-week "día de la semana"}
+   :field-fmts
+   {:minute       {:fmt/every-unit  "cada minuto"
+                   :fmt/every-nth   "cada %s minutos"
+                   :fmt/unit-value  "minuto %s"
+                   :fmt/range       "cada minuto de %s a %s"
+                   :fmt/range-step  "cada %s minutos de %s a %s"}
+    :hour         {:fmt/every-unit  "cada hora"
+                   :fmt/every-nth   "cada %s horas"
+                   :fmt/unit-value  "hora %s"
+                   :fmt/range       "cada hora de %s a %s"
+                   :fmt/range-step  "cada %s horas de %s a %s"}
+    :day-of-month {:fmt/every-unit  "cada día del mes"
+                   :fmt/every-nth   "cada %s días del mes"
+                   :fmt/unit-value  "día del mes %s"
+                   :fmt/range       "cada día del mes de %s a %s"
+                   :fmt/range-step  "cada %s días del mes de %s a %s"}
+    :month        {:fmt/every-unit  "cada mes"
+                   :fmt/every-nth   "cada %s meses"
+                   :fmt/unit-value  "mes %s"
+                   :fmt/range       "cada mes de %s a %s"
+                   :fmt/range-step  "cada %s meses de %s a %s"}
+    :day-of-week  {:fmt/every-unit  "cada día de la semana"
+                   :fmt/every-nth   "cada %s días de la semana"
+                   :fmt/unit-value  "día de la semana %s"
+                   :fmt/range       "cada día de la semana de %s a %s"
+                   :fmt/range-step  "cada %s días de la semana de %s a %s"}}
+   :nicknames          {"@yearly"   "cada 1 de enero a medianoche"
+                        "@annually" "cada 1 de enero a medianoche"
+                        "@monthly"  "el 1 de cada mes a medianoche"
+                        "@weekly"   "cada domingo a medianoche"
+                        "@daily"    "cada día a medianoche"
+                        "@hourly"   "cada hora"}
+   :ordinal-fn         (fn [n] (str n))
+   :time-fn            (fn [h m]
+                         (cond
+                           (and (= h "0") (= m "0")) "medianoche"
+                           (and (re-matches #"\d+" m) (re-matches #"\d+" h))
+                           (let [mi (Integer/parseInt m)]
+                             (if (zero? mi)
+                               (format "las %s:00" h)
+                               (format "las %s:%02d" h mi)))
+                           :else nil))
+   :midnight           "medianoche"
+   :every-day          "cada día"
+   :every-minute       "cada minuto"
+   :weekday            "día laborable"
+   :weekend            "fin de semana"
+   :fmt/verbose        "%s, %s, %s, %s"
+   :fmt/or             "%s o %s"
+   :fmt/every-unit     "cada %s"
+   :fmt/every-nth      "cada %s %s"
+   :fmt/unit-value     "%s %s"
+   :fmt/range          "cada %s de %s a %s"
+   :fmt/range-step     "cada %s %s de %s a %s"
+   :fmt/every-n-minutes    "cada %s minutos"
+   :fmt/every-n-hours      "cada %s horas"
+   :fmt/every-dow-at       "cada %s a %s"
+   :fmt/every-dom-at       "el %s de cada mes a %s"
+   :fmt/every-month-dom-at (fn [{:keys [day-of-month month time]}]
+                             (let [month-name (get es-month-names-genitive
+                                                   (Integer/parseInt month))]
+                               (format "cada %s de %s a %s"
+                                       day-of-month month-name time)))
+   :fmt/every-day-at       "cada día a %s"})
+
 (defn- ru-plural
   "Russian plural form for a numeric string.
    Returns one of three forms based on standard Russian grammar rules:

--- a/test/org/pilosus/kairos_cron_to_text_test.clj
+++ b/test/org/pilosus/kairos_cron_to_text_test.clj
@@ -381,6 +381,117 @@
         (is (= expected (kairos/cron->text cron {:locale locale/ru}))
             description)))))
 
+(def params-cron->text-es-simple
+  [["@yearly"
+    "cada 1 de enero a medianoche"
+    "Nickname @yearly"]
+   ["@annually"
+    "cada 1 de enero a medianoche"
+    "Nickname @annually"]
+   ["@monthly"
+    "el 1 de cada mes a medianoche"
+    "Nickname @monthly"]
+   ["@weekly"
+    "cada domingo a medianoche"
+    "Nickname @weekly"]
+   ["@daily"
+    "cada día a medianoche"
+    "Nickname @daily"]
+   ["@hourly"
+    "cada hora"
+    "Nickname @hourly"]
+   ["* * * * *"
+    "cada minuto"
+    "Every minute"]
+   ["*/5 * * * *"
+    "cada 5 minutos"
+    "Every 5 minutes"]
+   ["*/25 * * * *"
+    "cada 25 minutos"
+    "Double-digit minutes with step"]
+   ["0 */2 * * *"
+    "cada 2 horas"
+    "Every 2 hours"]
+   ["0 */12 * * *"
+    "cada 12 horas"
+    "Double-digit hours with step"]
+   ["0 9 * * *"
+    "cada día a las 9:00"
+    "Every day at 9:00"]
+   ["30 8 * * *"
+    "cada día a las 8:30"
+    "Every day at 8:30"]
+   ["0 0 * * *"
+    "cada día a medianoche"
+    "Every day at midnight"]
+   ["0 9 * * 1-5"
+    "cada día laborable a las 9:00"
+    "Every weekday at 9:00"]
+   ["0 9 * * 6,7"
+    "cada fin de semana a las 9:00"
+    "Every weekend at 9:00"]
+   ["0 9 * * 6,0"
+    "cada fin de semana a las 9:00"
+    "Every weekend at 9:00 (sun=0)"]
+   ["30 8 15 * *"
+    "el 15 de cada mes a las 8:30"
+    "Every 15th of month at 8:30"]
+   ["0 0 1 * *"
+    "el 1 de cada mes a medianoche"
+    "Every 1st of the month at midnight"]
+   ["0 0 25 12 *"
+    "cada 25 de diciembre a medianoche"
+    "Every December 25th at midnight"]
+   ["0 0 1 1 *"
+    "cada 1 de enero a medianoche"
+    "Every January 1st at midnight"]
+   ["0 0 14 2 *"
+    "cada 14 de febrero a medianoche"
+    "Every February 14th at midnight"]
+   ["0 12 3 10 *"
+    "cada 3 de octubre a las 12:00"
+    "Every October 3rd at noon"]])
+
+(deftest test-cron->text-es-simple
+  (testing "Test Spanish locale simple patterns"
+    (doseq [[cron expected description] params-cron->text-es-simple]
+      (testing cron
+        (is (= expected (kairos/cron->text cron {:locale locale/es}))
+            description)))))
+
+(def params-cron->text-es-complex
+  [["3-17 * * * *"
+    "cada minuto de 3 a 17, cada hora, cada día, cada mes"
+    "Simple range value"]
+   ["10-20/2 * * * *"
+    "cada 2 minutos de 10 a 20, cada hora, cada día, cada mes"
+    "Explicit range with step"]
+   ["1,2,17 * * * *"
+    "minuto 1, minuto 2, minuto 17, cada hora, cada día, cada mes"
+    "Simple list of values"]
+   ["* * 1-15 * *"
+    "cada minuto, cada hora, cada día del mes de 1 a 15, cada mes"
+    "Day of month only"]
+   ["* * * * 1-4"
+    "cada minuto, cada hora, cada día de la semana de lunes a jueves, cada mes"
+    "Day of week only"]
+   ["* * 1-15 * 1-4"
+    "cada minuto, cada hora, cada día del mes de 1 a 15 o cada día de la semana de lunes a jueves, cada mes"
+    "Day of month OR day of week"]
+   ["* * * Jan-May *"
+    "cada minuto, cada hora, cada día, cada mes de enero a mayo"
+    "Month range"]
+   ["cannot be parsed"
+    nil
+    "Wrong value"]])
+
+(deftest test-cron->text-es-complex
+  (testing "Test Spanish locale verbose patterns"
+    (doseq [[cron expected description] params-cron->text-es-complex]
+      (testing cron
+        (is (= expected (kairos/cron->text cron {:locale locale/es}))
+            description)))))
+
 (deftest test-cron->text-partial-locale
   (testing "Partial locale overrides merge with English defaults"
     (is (= "every day at minuit"


### PR DESCRIPTION
A follow-up for the #43 with locales support for `cron->text`